### PR TITLE
test: cover style enqueue function

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # KYLF-Worpress-Theme
 The custom child theme for the Know Your Local Florida website, built on the Streamit parent theme
+
+## Running tests
+
+1. Set up the WordPress test suite (see [WP tests instructions](https://make.wordpress.org/core/handbook/testing/automated-testing/phpunit/)) and export the `WP_TESTS_DIR` environment variable pointing to it.
+2. From the project root, execute:
+
+```bash
+phpunit
+```

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<phpunit bootstrap="tests/bootstrap.php" colors="true">
+    <testsuites>
+        <testsuite name="KYLF Theme Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,15 @@
+<?php
+$_tests_dir = getenv( 'WP_TESTS_DIR' ) ?: '/tmp/wordpress-tests-lib';
+
+if ( ! file_exists( $_tests_dir . '/includes/functions.php' ) ) {
+    fwrite( STDERR, "Could not find WordPress tests library at {$_tests_dir}\n" );
+    exit( 1 );
+}
+
+require_once $_tests_dir . '/includes/functions.php';
+
+tests_add_filter( 'muplugins_loaded', function() {
+    require dirname( __DIR__ ) . '/functions.php';
+} );
+
+require $_tests_dir . '/includes/bootstrap.php';

--- a/tests/test-style-enqueue.php
+++ b/tests/test-style-enqueue.php
@@ -1,0 +1,9 @@
+<?php
+class StyleEnqueueTest extends WP_UnitTestCase {
+    public function test_styles_are_enqueued() {
+        streamit_enqueue_styles();
+
+        $this->assertTrue( wp_style_is( 'parent-style', 'enqueued' ) );
+        $this->assertTrue( wp_style_is( 'child-style', 'enqueued' ) );
+    }
+}


### PR DESCRIPTION
## Summary
- add PHPUnit config and bootstrap for WordPress tests
- test style enqueueing for parent and child themes
- document how to run the test suite

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c127d42548320a4d74f52e048c2b8